### PR TITLE
Fixed mod.rs in Herorinn client

### DIFF
--- a/heroinn_client/src/module/mod.rs
+++ b/heroinn_client/src/module/mod.rs
@@ -1,3 +1,3 @@
 #[allow(non_snake_case)]
-pub mod Shell;
+pub mod shell;
 pub mod ftp;


### PR DESCRIPTION
Wrong Naming broke Building on Unix Based Systems 